### PR TITLE
Standardize settings.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: youtubeR
 Title: An Interface to the YouTube API
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: c(
     person("Kevin", "Kent", , "kentmkevin@gmail.com", role = c("aut", "cre")),
     person("Jon", "Harmon", , "jonthegeek@gmail.com", role = "aut",
@@ -18,7 +18,7 @@ Imports:
     curl,
     fs,
     glue,
-    httr2,
+    httr2 (>= 1.0.0),
     jsonlite,
     purrr,
     rlang,
@@ -30,5 +30,6 @@ Suggests:
     withr
 Config/testthat/edition: 3
 Encoding: UTF-8
+Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/aaa_authentication.R
+++ b/R/aaa_authentication.R
@@ -118,7 +118,8 @@ yt_authenticate <- function(client = yt_construct_client(),
     token <- httr2::oauth_flow_auth_code(
       client = client,
       auth_url = "https://accounts.google.com/o/oauth2/v2/auth",
-      scope = "https://www.googleapis.com/auth/youtube"
+      scope = "https://www.googleapis.com/auth/youtube",
+      redirect_uri = "http://127.0.0.1:8888"
     )
 
     the[[rlang::hash(client)]] <- token
@@ -184,8 +185,8 @@ yt_authenticate <- function(client = yt_construct_client(),
 #' @keywords internal
 .yt_req_auth <- function(request,
                          client = yt_construct_client(),
-                         cache_disk = getOption("yt_cache_disk", FALSE),
-                         cache_key = getOption("yt_cache_key", NULL),
+                         cache_disk = getOption("youtuberR.cache_disk", FALSE),
+                         cache_key = getOption("youtuberR.cache_key", NULL),
                          token = NULL) {
   if (!is.null(token)) {
     if (inherits(token, "httr2_token")) {
@@ -214,7 +215,8 @@ yt_authenticate <- function(client = yt_construct_client(),
       auth_url = "https://accounts.google.com/o/oauth2/v2/auth",
       scope = "https://www.googleapis.com/auth/youtube",
       cache_disk = cache_disk,
-      cache_key = cache_key
+      cache_key = cache_key,
+      redirect_uri = "http://127.0.0.1:8888"
     )
   )
 }

--- a/R/aaa_requests.R
+++ b/R/aaa_requests.R
@@ -24,8 +24,8 @@ yt_call_api <- function(endpoint,
                         body = NULL,
                         method = NULL,
                         client = yt_construct_client(),
-                        cache_disk = getOption("yt_cache_disk", FALSE),
-                        cache_key = getOption("yt_cache_key", NULL),
+                        cache_disk = getOption("youtuberR.cache_disk", FALSE),
+                        cache_key = getOption("youtuberR.cache_key", NULL),
                         token = NULL,
                         base_url = c(
                           "basic", "upload", "resumable_upload"
@@ -57,8 +57,10 @@ yt_call_api <- function(endpoint,
                              body = NULL,
                              method = NULL,
                              client = yt_construct_client(),
-                             cache_disk = getOption("yt_cache_disk", FALSE),
-                             cache_key = getOption("yt_cache_key", NULL),
+                             cache_disk = getOption("youtuberR.cache_disk",
+                                                    FALSE),
+                             cache_key = getOption("youtuberR.cache_key",
+                                                   NULL),
                              token = NULL,
                              base_url = c(
                                "basic", "upload", "resumable_upload"

--- a/R/playlist_items.R
+++ b/R/playlist_items.R
@@ -14,8 +14,10 @@
 get_playlist_items <- function(playlist_id,
                                max_results = 100,
                                client = yt_construct_client(),
-                               cache_disk = getOption("yt_cache_disk", FALSE),
-                               cache_key = getOption("yt_cache_key", NULL),
+                               cache_disk = getOption("youtuberR.cache_disk",
+                                                      FALSE),
+                               cache_key = getOption("youtuberR.cache_key",
+                                                     NULL),
                                token = NULL) {
   res <- yt_call_api(
     endpoint = "playlistItems",

--- a/R/videos.R
+++ b/R/videos.R
@@ -74,8 +74,9 @@ yt_videos_insert <- function(video_path,
                              status = yt_schema_video_status(),
                              recording_date = datetime(),
                              client = yt_construct_client(),
-                             cache_disk = getOption("yt_cache_disk", FALSE),
-                             cache_key = getOption("yt_cache_key", NULL),
+                             cache_disk = getOption("youtuberR.cache_disk",
+                                                    FALSE),
+                             cache_key = getOption("youtuberR.cache_key", NULL),
                              token = NULL) {
   body <- list(
     metadata = list(
@@ -119,8 +120,9 @@ yt_videos_update <- function(video_id,
                              status = yt_schema_video_status(),
                              recording_date = datetime(),
                              client = yt_construct_client(),
-                             cache_disk = getOption("yt_cache_disk", FALSE),
-                             cache_key = getOption("yt_cache_key", NULL),
+                             cache_disk = getOption("youtuberR.cache_disk",
+                                                    FALSE),
+                             cache_key = getOption("youtuberR.cache_key", NULL),
                              token = NULL) {
   # HACK: This body should be compared to the existing body for this video.
   # Missing pieces should be filled in from the existing body.
@@ -160,8 +162,9 @@ yt_videos_update <- function(video_id,
 #' @export
 yt_videos_delete <- function(video_id,
                              client = yt_construct_client(),
-                             cache_disk = getOption("yt_cache_disk", FALSE),
-                             cache_key = getOption("yt_cache_key", NULL),
+                             cache_disk = getOption("youtuberR.cache_disk",
+                                                    FALSE),
+                             cache_key = getOption("youtuberR.cache_key", NULL),
                              token = NULL) {
   result <- yt_call_api(
     endpoint = "videos",

--- a/R/youtubeR-package.R
+++ b/R/youtubeR-package.R
@@ -8,6 +8,6 @@ NULL
 
 # The "the" environment is a trick borrowed from the Posit open source team.
 # They set up an internal package environment, "the", so they can refer to
-# things within the package as "the$thing_i_want". It's intendend to improve
+# things within the package as "the$thing_i_want". It's intended to improve
 # readability.
 the <- rlang::new_environment()

--- a/man/dot-prepare_request.Rd
+++ b/man/dot-prepare_request.Rd
@@ -10,8 +10,8 @@
   body = NULL,
   method = NULL,
   client = yt_construct_client(),
-  cache_disk = getOption("yt_cache_disk", FALSE),
-  cache_key = getOption("yt_cache_key", NULL),
+  cache_disk = getOption("youtuberR.cache_disk", FALSE),
+  cache_key = getOption("youtuberR.cache_key", NULL),
   token = NULL,
   base_url = c("basic", "upload", "resumable_upload")
 )
@@ -33,8 +33,9 @@ Case is ignored.}
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/dot-yt_req_auth.Rd
+++ b/man/dot-yt_req_auth.Rd
@@ -7,8 +7,8 @@
 .yt_req_auth(
   request,
   client = yt_construct_client(),
-  cache_disk = getOption("yt_cache_disk", FALSE),
-  cache_key = getOption("yt_cache_key", NULL),
+  cache_disk = getOption("youtuberR.cache_disk", FALSE),
+  cache_key = getOption("youtuberR.cache_key", NULL),
   token = NULL
 )
 }
@@ -19,8 +19,9 @@
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/get_my_channel_detail_playlist_ids.Rd
+++ b/man/get_my_channel_detail_playlist_ids.Rd
@@ -16,8 +16,9 @@ get_my_channel_detail_playlist_ids(
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/get_playlist_items.Rd
+++ b/man/get_playlist_items.Rd
@@ -8,8 +8,8 @@ get_playlist_items(
   playlist_id,
   max_results = 100,
   client = yt_construct_client(),
-  cache_disk = getOption("yt_cache_disk", FALSE),
-  cache_key = getOption("yt_cache_key", NULL),
+  cache_disk = getOption("youtuberR.cache_disk", FALSE),
+  cache_key = getOption("youtuberR.cache_key", NULL),
   token = NULL
 )
 }
@@ -22,8 +22,9 @@ get_playlist_items(
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/get_playlist_video_ids.Rd
+++ b/man/get_playlist_video_ids.Rd
@@ -22,8 +22,9 @@ get_playlist_video_ids(
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/get_upload_playlist_id.Rd
+++ b/man/get_upload_playlist_id.Rd
@@ -16,8 +16,9 @@ get_upload_playlist_id(
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/get_video_processing_details.Rd
+++ b/man/get_video_processing_details.Rd
@@ -19,8 +19,9 @@ get_video_processing_details(
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/yt_call_api.Rd
+++ b/man/yt_call_api.Rd
@@ -10,8 +10,8 @@ yt_call_api(
   body = NULL,
   method = NULL,
   client = yt_construct_client(),
-  cache_disk = getOption("yt_cache_disk", FALSE),
-  cache_key = getOption("yt_cache_key", NULL),
+  cache_disk = getOption("youtuberR.cache_disk", FALSE),
+  cache_key = getOption("youtuberR.cache_key", NULL),
   token = NULL,
   base_url = c("basic", "upload", "resumable_upload")
 )
@@ -33,8 +33,9 @@ Case is ignored.}
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/yt_videos_delete.Rd
+++ b/man/yt_videos_delete.Rd
@@ -7,8 +7,8 @@
 yt_videos_delete(
   video_id,
   client = yt_construct_client(),
-  cache_disk = getOption("yt_cache_disk", FALSE),
-  cache_key = getOption("yt_cache_key", NULL),
+  cache_disk = getOption("youtuberR.cache_disk", FALSE),
+  cache_key = getOption("youtuberR.cache_key", NULL),
   token = NULL
 )
 }
@@ -21,8 +21,9 @@ id property specifies the video's ID.}
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/yt_videos_insert.Rd
+++ b/man/yt_videos_insert.Rd
@@ -11,8 +11,8 @@ yt_videos_insert(
   status = yt_schema_video_status(),
   recording_date = datetime(),
   client = yt_construct_client(),
-  cache_disk = getOption("yt_cache_disk", FALSE),
-  cache_key = getOption("yt_cache_key", NULL),
+  cache_disk = getOption("youtuberR.cache_disk", FALSE),
+  cache_key = getOption("youtuberR.cache_key", NULL),
   token = NULL
 )
 }
@@ -40,8 +40,9 @@ recorded.}
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}

--- a/man/yt_videos_update.Rd
+++ b/man/yt_videos_update.Rd
@@ -11,8 +11,8 @@ yt_videos_update(
   status = yt_schema_video_status(),
   recording_date = datetime(),
   client = yt_construct_client(),
-  cache_disk = getOption("yt_cache_disk", FALSE),
-  cache_key = getOption("yt_cache_key", NULL),
+  cache_disk = getOption("youtuberR.cache_disk", FALSE),
+  cache_key = getOption("youtuberR.cache_key", NULL),
   token = NULL
 )
 }
@@ -42,8 +42,9 @@ recorded.}
 
 \item{cache_disk}{Should the access token be cached on disk? This reduces
 the number of times that you need to re-authenticate at the cost of
-storing access credentials on disk. Cached tokens are encrypted and
-automatically deleted 30 days after creation.}
+storing access credentials on disk.
+
+Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you are authenticating with multiple users using the same
 client, use this key to differentiate between those users.}


### PR DESCRIPTION
This is the version I have locally and have been using for months. I kept meaning to "finish" this and never submitted it, but it makes more sense to at least match between my local copy and the "real" version! All I did was rename the options to a safer format (with the full name of this package included so we don't accidentally overlap with some other YouTube package), and add explicit redirect_uri settings (I believe that requirement was added in httr2 after we worked on this).

Still to-do: Replace a lot of this with {nectar} (and/or use beekeeper to re-construct the package).